### PR TITLE
enable: github action for main and release-pro

### DIFF
--- a/.github/workflows/sd-webui-server.yml
+++ b/.github/workflows/sd-webui-server.yml
@@ -22,8 +22,8 @@ on:
   push:
     branches:
       - development
-      # - main
-      # - release-pro
+      - main
+      - release-pro
 
 env:
   SERVICE_NAMES: sd-webui-server


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow triggers to activate on `main` and `release-pro` branches instead of `development`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->