### PR TITLE
Add concurrency settings to GitHub Actions

### DIFF
--- a/.github/workflows/hydra.yaml
+++ b/.github/workflows/hydra.yaml
@@ -11,6 +11,11 @@ env:
   SERVICE_NAMES: sd-webui-server
 
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
   
 jobs:
   prepare-env:

--- a/.github/workflows/sd-webui-server.yml
+++ b/.github/workflows/sd-webui-server.yml
@@ -29,6 +29,11 @@ env:
   SERVICE_NAMES: sd-webui-server
 
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
   
 jobs:
   prepare-env:


### PR DESCRIPTION
This PR adds concurrency settings to GitHub Actions to prevent overlapping runs.