### PR TITLE
MAIN: Add CN environment to prod-release workflow

### DIFF
--- a/.github/workflows/prod-release.yaml
+++ b/.github/workflows/prod-release.yaml
@@ -15,6 +15,7 @@ on:
         options:
           - PRO
           - APP
+          - CN
 
 env:
   WORKLOAD_NAME: sd-webui-server


### PR DESCRIPTION
This PR adds the CN environment option to the production release workflow.